### PR TITLE
10 sorting queries articles

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -128,18 +128,8 @@ describe("GET /api/articles", () => {
   })
 });
 
-describe("GET /api/articles?order=desc", () => {
+describe("GET /api/articles?order=asc", () => {
   test("200: Responds with articles order in descending order by created_at", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=DESC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { descending: true });
-  });
-
-  test("200: Responds with articles order in ascending order by created_at", async () => {
     const response = await request(app)
       .get("/api/articles?sort_by=created_at&order=ASC")
       .expect(200)
@@ -147,21 +137,18 @@ describe("GET /api/articles?order=desc", () => {
     const result = response.body
 
     expect(result).toBeSortedBy("created_at", { ascending: true });
-
   });
 
-  test("200: Defaults to ascending order when order is not provided", async () => {
+  test("200: Responds with articles order in ascending order by created_at", async () => {
     const response = await request(app)
-
-      .get("/api/articles")
+      .get("/api/articles?sort_by=created_at&order=DESC")
       .expect(200)
 
     const result = response.body
 
-    expect(result).toBeSortedBy("created_at", { ascending: true });
+    expect(result).toBeSortedBy("created_at", { descending: true });
 
   });
-
   test("400: Responds with an error message for invalid sort_by", async () => {
 
     const response = await request(app)
@@ -436,6 +423,73 @@ describe("GET /api/users", () => {
     const error = response.body
 
     expect(error).toEqual({ msg: "Users not found" });
+  });
+});
+
+describe("GET /api/articles?order=desc", () => {
+  test("200: Responds with articles order in descending order by created_at", async () => {
+    const response = await request(app)
+      .get("/api/articles?sort_by=created_at&order=DESC")
+      .expect(200)
+
+    const result = response.body
+
+    expect(result).toBeSortedBy("created_at", { descending: true });
+  });
+
+  test("200: Responds with articles order in ascending order by author", async () => {
+    const response = await request(app)
+      .get("/api/articles?sort_by=author&order=ASC")
+      .expect(200)
+
+    const result = response.body
+
+    expect(result).toBeSortedBy("author", { ascending: true });
+
+  });
+
+  test("200: Defaults to descending order when order is not provided", async () => {
+    const response = await request(app)
+
+      .get("/api/articles?sort_by=created_at")
+      .expect(200)
+
+    const result = response.body
+
+    expect(result).toBeSortedBy("created_at", { descending: true });
+
+  });
+  test("200: Defaults to created_at when sort_by is not provided", async () => {
+    const response = await request(app)
+
+      .get("/api/articles?order=ASC")
+      .expect(200)
+
+    const result = response.body
+
+    expect(result).toBeSortedBy("created_at", { ascending: true });
+
+  });
+
+  test("400: Responds with an error message for invalid sort_by", async () => {
+
+    const response = await request(app)
+      .get("/api/articles?sort_by=invalid_column&order=asc")
+      .expect(400);
+
+    const error = response.body
+
+    expect(error).toEqual({ msg: "Invalid sort_by column" });
+  })
+
+  test("400: Responds with an error message if order is invalid", async () => {
+    const response = await request(app)
+      .get("/api/articles?sort_by=created_at&order=invalid")
+      .expect(400);
+
+    const error = response.body
+
+    expect(error).toEqual({ msg: "Invalid order value" });
   });
 });
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -43,8 +43,18 @@ describe("GET /api/topics", () => {
       expect(topic).toHaveProperty("slug")
       expect(topic).toHaveProperty("description")
     })
-  })
+  });
+  test("404: Responds with an error when not topics found", async () => {
+    await db.query("DELETE FROM topics;");
+    
+    const response = await request(app)
+      .get("/api/topics")
+      .expect(404);
 
+    const error = response.body
+
+    expect(error).toEqual({ msg: "Topics not found" });
+  });
 });
 
 describe("GET /api/articles/:article_id", () => {
@@ -91,7 +101,7 @@ describe("GET /api/articles/:article_id", () => {
 
     expect(error).toEqual({ msg: "Article not found" });
   })
-})
+});
 
 describe("GET /api/articles", () => {
   test("200: Responds with an array of articles objects", async () => {
@@ -116,7 +126,7 @@ describe("GET /api/articles", () => {
       expect(article).toHaveProperty("article_img_url")
     })
   })
-})
+});
 
 describe("GET /api/articles?order=desc", () => {
   test("200: Responds with articles order in descending order by created_at", async () => {
@@ -229,7 +239,7 @@ describe("GET /api/articles/:article_id/comments", () => {
 
     expect(error).toEqual({ msg: "Article not found" });
   })
-})
+});
 
 
 describe("POST /api/articles/:article_id/comments", () => {
@@ -396,5 +406,36 @@ describe("DELETE /api/comments/:comment_id", () => {
     expect(error).toEqual({ msg: "Comment not found" });
   });
 
+});
+
+describe("GET /api/users", () => {
+  test("200: Responds with an array of users objects", async () => {
+
+    const response = await request(app)
+      .get("/api/users")
+      .expect(200);
+
+    const users = response.body
+
+    expect(users).toBeInstanceOf(Array);
+    expect(users.length).toBeGreaterThan(0);
+
+    users.forEach((user) => {
+      expect(user).toHaveProperty("name");
+      expect(user).toHaveProperty("username");
+      expect(user).toHaveProperty("avatar_url");
+    })
+  });
+  test("404: Responds with an error when not users found", async () => {
+    await db.query("DELETE FROM users;");
+    
+    const response = await request(app)
+      .get("/api/users")
+      .expect(404);
+
+    const error = response.body
+
+    expect(error).toEqual({ msg: "Users not found" });
+  });
 });
 

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const { getTopics } = require("./controllers/topics.controller")
 const apiInfo = require('../backend_project_north/endpoints.json');
 const { getArticleById, getAllArticles, patchArticle } = require("./controllers/articles.controller");
 const { postComments, getArticleCommentsById, deleteComment } = require("./controllers/comments.controller");
+const { getUsers } = require("./controllers/users.controller");
 
 const app = express()
 
@@ -25,11 +26,14 @@ app.get("/api/articles", getAllArticles);
 
 app.get("/api/articles/:article_id/comments", getArticleCommentsById);
 
-app.post("/api/articles/:article_id/comments",postComments)
+app.post("/api/articles/:article_id/comments", postComments);
 
-app.patch("/api/articles/:article_id",patchArticle);
+app.patch("/api/articles/:article_id", patchArticle);
 
-app.delete("/api/comments/:comment_id",deleteComment)
+app.delete("/api/comments/:comment_id", deleteComment);
+
+app.get("/api/users", getUsers);
+
 
 app.use((err, req, res, next) => {
     // console.error(err);

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -6,7 +6,7 @@ const { fetchArticleById, fetchAllArticles, updateArticleById } = require("../mo
 exports.getAllArticles = async (req, res, next) => {
   try {
 
-    const { sort_by = "created_at", order = "ASC" } = req.query;
+    const { sort_by = "created_at", order = "DESC" } = req.query;
 
     const articles = await fetchAllArticles(sort_by, order)
 

--- a/controllers/topics.controller.js
+++ b/controllers/topics.controller.js
@@ -5,9 +5,15 @@ const { fetchAllTopics } = require("../models/topics.model");
 
 exports.getTopics = async (req, res, next) => {
     try {
+
         const topics = await fetchAllTopics();
-        // console.log(topics)
-        res.status(200).json(topics);
+
+        if (topics.length === 0) {
+            throw { status: 404, msg: "Topics not found" };
+        }
+
+        res.status(200).send(topics);
+
     } catch (err) {
         next(err)
     }

--- a/controllers/users.controller.js
+++ b/controllers/users.controller.js
@@ -1,0 +1,20 @@
+const response = require("express");
+const db = require("../db/connection");
+const { fetchUsers } = require("../models/users.model");
+
+exports.getUsers = async (req, res, next) => {
+    try {
+
+        const usersObtained = await fetchUsers();
+       
+        if (usersObtained.length === 0) {
+
+            throw { status: 404, msg: "Users not found" };
+        }
+
+        return res.status(200).send(usersObtained);
+
+    } catch (err) {
+        next(err)
+    }
+}

--- a/endpoints.json
+++ b/endpoints.json
@@ -244,5 +244,38 @@
         }
       }
     }
+  },
+  "GET /api/users": {
+  "description": "Retrieves all users from the database",
+  "parameters": {},
+  "responses": {
+    "200": {
+      "description": "Successfully retrieved the list of users",
+      "body": {
+        "users": [
+          {
+            "name": {
+              "type": "string",
+              "description": "The name of the user"
+            },
+            "username": {
+              "type": "string",
+              "description": "The email of the user"
+            },    
+             "avatar_url": {
+              "type": "imagen",
+              "description": "The imagen of the user"
+            }
+          }
+        ]
+      }
+    },
+    "404": {
+      "description": "No users found in the database",
+      "body": {
+        "msg": "Users not found"
+      }
+    }
   }
+}
 }

--- a/endpoints.json
+++ b/endpoints.json
@@ -246,36 +246,80 @@
     }
   },
   "GET /api/users": {
-  "description": "Retrieves all users from the database",
-  "parameters": {},
-  "responses": {
-    "200": {
-      "description": "Successfully retrieved the list of users",
-      "body": {
-        "users": [
-          {
-            "name": {
-              "type": "string",
-              "description": "The name of the user"
-            },
-            "username": {
-              "type": "string",
-              "description": "The email of the user"
-            },    
-             "avatar_url": {
-              "type": "imagen",
-              "description": "The imagen of the user"
+    "description": "Retrieves all users from the database",
+    "parameters": {},
+    "responses": {
+      "200": {
+        "description": "Successfully retrieved the list of users",
+        "body": {
+          "users": [
+            {
+              "name": {
+                "type": "string",
+                "description": "The name of the user"
+              },
+              "username": {
+                "type": "string",
+                "description": "The email of the user"
+              },
+              "avatar_url": {
+                "type": "imagen",
+                "description": "The imagen of the user"
+              }
             }
-          }
-        ]
+          ]
+        }
+      },
+      "404": {
+        "description": "No users found in the database",
+        "body": {
+          "msg": "Users not found"
+        }
       }
-    },
-    "404": {
-      "description": "No users found in the database",
-      "body": {
-        "msg": "Users not found"
+    }
+  },
+  "GET /api/articles?": {
+    "description": "Retrieves a list of articles with optional sorting queries.",
+    "queryParams": [
+      {
+        "name": "sort_by",
+        "type": "string",
+        "description": "Column name to sort the articles by (e.g., 'title', 'votes', 'created_at'). Defaults to 'created_at'."
+      },
+      {
+        "name": "order",
+        "type": "string",
+        "description": "Sorting order: 'asc' for ascending or 'desc' for descending. Defaults to 'desc'."
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Returns a list of articles sorted according to the provided parameters.",
+        "content": {
+          "application/json": {
+            "example": [
+              {
+                "article_id": 1,
+                "title": "Interesting Article",
+                "topic": "news",
+                "author": "johndoe",
+                "created_at": "2023-05-15T10:30:00.000Z",
+                "votes": 100,
+                "comment_count": 5
+              },
+              {
+                "article_id": 2,
+                "title": "Another Great Read",
+                "topic": "sports",
+                "author": "janedoe",
+                "created_at": "2023-05-14T08:15:00.000Z",
+                "votes": 75,
+                "comment_count": 2
+              }
+            ]
+          }
+        }
       }
     }
   }
-}
 }

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -1,7 +1,7 @@
 const db = require("../db/connection");
 
 
-exports.fetchAllArticles = async (sort_by = "created_at", order = "ASC") => {
+exports.fetchAllArticles = async (sort_by = "created_at", order = "DESC") => {
     try {
         const validSortColumns = ["created_at", "article_id", "title", "votes", "article_img_url", "author", "topic", "comment_count"];
 

--- a/models/topics.model.js
+++ b/models/topics.model.js
@@ -6,14 +6,14 @@ exports.fetchAllTopics = async () => {
         let baseQuery = `
         SELECT
         slug, description
-        FROM topics`;
+        FROM topics;`;
 
         const result = await db.query(baseQuery);
 
         return result.rows;
 
     } catch (err) {
-
+        throw err
     }
 
 }

--- a/models/users.model.js
+++ b/models/users.model.js
@@ -1,0 +1,17 @@
+const db = require("../db/connection");
+
+exports.fetchUsers = async () => {
+
+    try {
+        const usersQuery = `
+        SELECT *
+        FROM users;`;
+
+        const users = await db.query(usersQuery);
+
+        return users.rows;
+
+    } catch (err) {
+        throw err
+    }
+}


### PR DESCRIPTION
This update improves how we handle article sorting in the API. Now, if the sort_by parameter is not provided in the request, the system will automatically sort articles by the created_at field in descending order. If the order parameter is included, it will determine whether the sorting is ascending or descending.

For example:

If no sort_by is given, articles will be sorted by created_at  by default.
If no order is given, articles will be order DESC in descending order by default.
If the order is specified as ASC or DESC, the articles will be sorted accordingly.
This change ensures that users can still get the articles in a predictable order, even if they only provide the order parameter.