### PR TITLE
12 comment count by article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -28,7 +28,7 @@ describe("GET /api", () => {
 });
 
 describe("GET /api/topics", () => {
-  test("200: Responds with an array of topic objects", async () => {
+  test("200: Responds with an array of objects of topics", async () => {
 
     const response = await request(app)
       .get("/api/topics")
@@ -46,7 +46,7 @@ describe("GET /api/topics", () => {
   });
   test("404: Responds with an error when not topics found", async () => {
     await db.query("DELETE FROM topics;");
-    
+
     const response = await request(app)
       .get("/api/topics")
       .expect(404);
@@ -58,7 +58,7 @@ describe("GET /api/topics", () => {
 });
 
 describe("GET /api/articles/:article_id", () => {
-  test("200: Responds with an array of articles objects", async () => {
+  test("200: Responds with an article filter by id", async () => {
 
     const response = await request(app)
       .get("/api/articles/1")
@@ -66,7 +66,7 @@ describe("GET /api/articles/:article_id", () => {
 
     const articles = response.body
 
-    expect(articles).toBeInstanceOf(Object);
+    expect(articles).toBeInstanceOf(Array);
     expect(articles.length).toBeGreaterThan(0);
 
     articles.forEach((article) => {
@@ -78,8 +78,8 @@ describe("GET /api/articles/:article_id", () => {
       expect(article).toHaveProperty("created_at")
       expect(article).toHaveProperty("votes")
       expect(article).toHaveProperty("article_img_url")
-    })
-  })
+    });
+  });
   test("400: Responds with an error message for invalid article_id", async () => {
 
     const response = await request(app)
@@ -90,7 +90,7 @@ describe("GET /api/articles/:article_id", () => {
 
     expect(error).toEqual({ msg: "Invalid article_id" });
 
-  })
+  });
   test("404: Responds with an error message for not found article_id", async () => {
 
     const response = await request(app)
@@ -100,9 +100,61 @@ describe("GET /api/articles/:article_id", () => {
     const error = response.body;
 
     expect(error).toEqual({ msg: "Article not found" });
-  })
-});
+  });
+  describe("comment_count property", () => {
+    test("200: Responds with an article including comment_count", async () => {
 
+      const response = await request(app)
+        .get("/api/articles/1")
+        .expect(200);
+
+      const article = response.body
+
+      expect(article).toBeInstanceOf(Array);
+      expect(article.length).toBeGreaterThan(0);
+
+      console.log(article, "adivina donde estoy")
+
+      expect(isNaN(Number(article.comment_count))).toBe(true);
+      article.forEach((article_comment) => {
+        expect(article_comment).toHaveProperty("comment_count");
+      });
+    });
+    test("200: Responds with comment_count= 0 if no comments ", async () => {
+
+      const response = await request(app)
+        .get("/api/articles/2")
+        .expect(200);
+
+      const article = response.body
+
+      article.forEach((article_comment) => {
+        expect(article_comment.comment_count).toBe("0");
+      });
+    });
+    test("400: Responds with an error message for invalid article_id", async () => {
+
+      const response = await request(app)
+        .get("/api/articles/h")
+        .expect(400);
+
+      const error = response.body
+
+      expect(error).toEqual({ msg: "Invalid article_id" });
+
+    });
+    test("404: Responds with an error message for not found article_id", async () => {
+
+      const response = await request(app)
+        .get("/api/articles/9099")
+        .expect(404);
+
+      const error = response.body;
+
+      expect(error).toEqual({ msg: "Article not found" });
+    })
+  });
+});
 describe("GET /api/articles", () => {
   test("200: Responds with an array of articles objects", async () => {
 
@@ -126,45 +178,57 @@ describe("GET /api/articles", () => {
       expect(article).toHaveProperty("article_img_url")
     });
   });
+  test("404: Responds with an error when not articles found", async () => {
+    await db.query("DELETE FROM articles;");
+
+    const response = await request(app)
+      .get("/api/articles")
+      .expect(404);
+
+    const error = response.body
+
+    expect(error).toEqual({ msg: "Articles not found" });
+  });
+
   describe("GET /api/articles?order=asc", () => {
     test("200: Responds with articles order in ascending order by created_at", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=ASC")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("created_at", { ascending: true });
     });
-  
+
     test("200: Responds with articles order in descending order by created_at", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=DESC")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("created_at", { descending: true });
-  
+
     });
     test("400: Responds with an error message for invalid sort_by", async () => {
-  
+
       const response = await request(app)
         .get("/api/articles?sort_by=invalid_column&order=asc")
         .expect(400);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Invalid sort_by column" });
     });
-  
+
     test("400: Responds with an error message if order is invalid", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=invalid")
         .expect(400);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Invalid order value" });
     });
   });
@@ -173,64 +237,64 @@ describe("GET /api/articles", () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=DESC")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("created_at", { descending: true });
     });
-  
+
     test("200: Responds with articles order in ascending order by author", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=author&order=ASC")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("author", { ascending: true });
-  
+
     });
-  
+
     test("200: Defaults to descending order when order is not provided", async () => {
       const response = await request(app)
-  
+
         .get("/api/articles?sort_by=created_at")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("created_at", { descending: true });
-  
+
     });
     test("200: Defaults to created_at when sort_by is not provided", async () => {
       const response = await request(app)
-  
+
         .get("/api/articles?order=ASC")
         .expect(200)
-  
+
       const result = response.body
-  
+
       expect(result).toBeSortedBy("created_at", { ascending: true });
-  
+
     });
-  
+
     test("400: Responds with an error message for invalid sort_by", async () => {
-  
+
       const response = await request(app)
         .get("/api/articles?sort_by=invalid_column&order=asc")
         .expect(400);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Invalid sort_by column" });
     });
-  
+
     test("400: Responds with an error message if order is invalid", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=invalid")
         .expect(400);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Invalid order value" });
     });
   });
@@ -239,48 +303,48 @@ describe("GET /api/articles", () => {
       const response = await request(app)
         .get("/api/articles?topic=mitch")
         .expect(200)
-  
-        const articlesByTopic = response.body
-  
+
+      const articlesByTopic = response.body
+
       expect(articlesByTopic).toBeInstanceOf(Array);
-  
+
       expect(articlesByTopic.length).toBeGreaterThan(0);
-      expect(articlesByTopic.every((article) => { return article.topic === "mitch"})).toBe(true);
-  
+      expect(articlesByTopic.every((article) => { return article.topic === "mitch" })).toBe(true);
+
     });
     test("200: Responds with articles when not topic value", async () => {
       const response = await request(app)
         .get("/api/articles")
         .expect(200)
-  
-        const articlesByTopic = response.body
-  
+
+      const articlesByTopic = response.body
+
       expect(articlesByTopic).toBeInstanceOf(Array);
-  
+
       expect(articlesByTopic.length).toBeGreaterThan(0);
-  
+
     });
     test("404: Responds with an error message topic not found", async () => {
-  
+
       const response = await request(app)
         .get("/api/articles?topic=nonexistent_topic")
         .expect(404);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Topic not found" });
     });
-  
+
     test("400: Responds with an error message if order is invalid", async () => {
       const response = await request(app)
         .get("/api/articles?sort_by=created_at&order=invalid")
         .expect(400);
-  
+
       const error = response.body
-  
+
       expect(error).toEqual({ msg: "Invalid order value" });
     });
-  });  
+  });
 });
 
 describe("GET /api/articles/:article_id/comments", () => {
@@ -303,8 +367,19 @@ describe("GET /api/articles/:article_id/comments", () => {
       expect(comment).toHaveProperty("created_at")
       expect(comment).toHaveProperty("votes")
     })
+    expect(comments).toBeSortedBy("created_at" , { descending: true });
   })
-  test("200: Responds with an array of comments objects", async () => {
+  test("200: Responds with an array of comments sorted by created_at in descending order", async () => {
+
+    const response = await request(app)
+      .get("/api/articles/1/comments")
+      .expect(200);
+
+    const comments = response.body
+
+    expect(comments).toBeSortedBy("created_at" , { descending: true });
+  })
+  test("200: Responds with an empty array when not comments found", async () => {
 
     const response = await request(app)
       .get("/api/articles/2/comments")
@@ -314,9 +389,9 @@ describe("GET /api/articles/:article_id/comments", () => {
 
     expect(comments).toBeInstanceOf(Array);
     expect(comments.length).toBe(0);
+    expect(comments).toEqual([]);
 
-  })
-
+  });
   test("400: Responds with an error message for invalid article_id", async () => {
 
     const response = await request(app)
@@ -483,7 +558,7 @@ describe("DELETE /api/comments/:comment_id", () => {
 
     const comment = response.body
 
-    expect(comment).toEqual({msg: "Comment deletion was sucessed"});
+    expect(comment).toEqual({ msg: "Comment deletion was sucessed" });
   });
   test("400: Responds with an error when 'comment_id' is not a number", async () => {
     const response = await request(app)
@@ -526,7 +601,7 @@ describe("GET /api/users", () => {
   });
   test("404: Responds with an error when not users found", async () => {
     await db.query("DELETE FROM users;");
-    
+
     const response = await request(app)
       .get("/api/users")
       .expect(404);

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -124,51 +124,163 @@ describe("GET /api/articles", () => {
       expect(article).toHaveProperty("created_at")
       expect(article).toHaveProperty("votes")
       expect(article).toHaveProperty("article_img_url")
-    })
-  })
-});
-
-describe("GET /api/articles?order=asc", () => {
-  test("200: Responds with articles order in descending order by created_at", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=ASC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { ascending: true });
+    });
   });
-
-  test("200: Responds with articles order in ascending order by created_at", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=DESC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { descending: true });
-
+  describe("GET /api/articles?order=asc", () => {
+    test("200: Responds with articles order in ascending order by created_at", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=ASC")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("created_at", { ascending: true });
+    });
+  
+    test("200: Responds with articles order in descending order by created_at", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=DESC")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("created_at", { descending: true });
+  
+    });
+    test("400: Responds with an error message for invalid sort_by", async () => {
+  
+      const response = await request(app)
+        .get("/api/articles?sort_by=invalid_column&order=asc")
+        .expect(400);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Invalid sort_by column" });
+    });
+  
+    test("400: Responds with an error message if order is invalid", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=invalid")
+        .expect(400);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Invalid order value" });
+    });
   });
-  test("400: Responds with an error message for invalid sort_by", async () => {
-
-    const response = await request(app)
-      .get("/api/articles?sort_by=invalid_column&order=asc")
-      .expect(400);
-
-    const error = response.body
-
-    expect(error).toEqual({ msg: "Invalid sort_by column" });
-  })
-
-  test("400: Responds with an error message if order is invalid", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=invalid")
-      .expect(400);
-
-    const error = response.body
-
-    expect(error).toEqual({ msg: "Invalid order value" });
+  describe("GET /api/articles?order=desc", () => {
+    test("200: Responds with articles order in descending order by created_at", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=DESC")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("created_at", { descending: true });
+    });
+  
+    test("200: Responds with articles order in ascending order by author", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=author&order=ASC")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("author", { ascending: true });
+  
+    });
+  
+    test("200: Defaults to descending order when order is not provided", async () => {
+      const response = await request(app)
+  
+        .get("/api/articles?sort_by=created_at")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("created_at", { descending: true });
+  
+    });
+    test("200: Defaults to created_at when sort_by is not provided", async () => {
+      const response = await request(app)
+  
+        .get("/api/articles?order=ASC")
+        .expect(200)
+  
+      const result = response.body
+  
+      expect(result).toBeSortedBy("created_at", { ascending: true });
+  
+    });
+  
+    test("400: Responds with an error message for invalid sort_by", async () => {
+  
+      const response = await request(app)
+        .get("/api/articles?sort_by=invalid_column&order=asc")
+        .expect(400);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Invalid sort_by column" });
+    });
+  
+    test("400: Responds with an error message if order is invalid", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=invalid")
+        .expect(400);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Invalid order value" });
+    });
   });
+  describe("GET /api/articles?topic=anything", () => {
+    test("200: Responds with articles filter for topic value", async () => {
+      const response = await request(app)
+        .get("/api/articles?topic=mitch")
+        .expect(200)
+  
+        const articlesByTopic = response.body
+  
+      expect(articlesByTopic).toBeInstanceOf(Array);
+  
+      expect(articlesByTopic.length).toBeGreaterThan(0);
+      expect(articlesByTopic.every((article) => { return article.topic === "mitch"})).toBe(true);
+  
+    });
+    test("200: Responds with articles when not topic value", async () => {
+      const response = await request(app)
+        .get("/api/articles")
+        .expect(200)
+  
+        const articlesByTopic = response.body
+  
+      expect(articlesByTopic).toBeInstanceOf(Array);
+  
+      expect(articlesByTopic.length).toBeGreaterThan(0);
+  
+    });
+    test("404: Responds with an error message topic not found", async () => {
+  
+      const response = await request(app)
+        .get("/api/articles?topic=nonexistent_topic")
+        .expect(404);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Topic not found" });
+    });
+  
+    test("400: Responds with an error message if order is invalid", async () => {
+      const response = await request(app)
+        .get("/api/articles?sort_by=created_at&order=invalid")
+        .expect(400);
+  
+      const error = response.body
+  
+      expect(error).toEqual({ msg: "Invalid order value" });
+    });
+  });  
 });
 
 describe("GET /api/articles/:article_id/comments", () => {
@@ -227,7 +339,6 @@ describe("GET /api/articles/:article_id/comments", () => {
     expect(error).toEqual({ msg: "Article not found" });
   })
 });
-
 
 describe("POST /api/articles/:article_id/comments", () => {
   test("201: Responds with a insert comment ", async () => {
@@ -425,71 +536,3 @@ describe("GET /api/users", () => {
     expect(error).toEqual({ msg: "Users not found" });
   });
 });
-
-describe("GET /api/articles?order=desc", () => {
-  test("200: Responds with articles order in descending order by created_at", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=DESC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { descending: true });
-  });
-
-  test("200: Responds with articles order in ascending order by author", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=author&order=ASC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("author", { ascending: true });
-
-  });
-
-  test("200: Defaults to descending order when order is not provided", async () => {
-    const response = await request(app)
-
-      .get("/api/articles?sort_by=created_at")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { descending: true });
-
-  });
-  test("200: Defaults to created_at when sort_by is not provided", async () => {
-    const response = await request(app)
-
-      .get("/api/articles?order=ASC")
-      .expect(200)
-
-    const result = response.body
-
-    expect(result).toBeSortedBy("created_at", { ascending: true });
-
-  });
-
-  test("400: Responds with an error message for invalid sort_by", async () => {
-
-    const response = await request(app)
-      .get("/api/articles?sort_by=invalid_column&order=asc")
-      .expect(400);
-
-    const error = response.body
-
-    expect(error).toEqual({ msg: "Invalid sort_by column" });
-  })
-
-  test("400: Responds with an error message if order is invalid", async () => {
-    const response = await request(app)
-      .get("/api/articles?sort_by=created_at&order=invalid")
-      .expect(400);
-
-    const error = response.body
-
-    expect(error).toEqual({ msg: "Invalid order value" });
-  });
-});
-

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -24,6 +24,10 @@ exports.getAllArticles = async (req, res, next) => {
       articles = await fetchAllArticles(sort_by, order)
 
     };
+
+    if(articles.length === 0) {
+      throw {status: 404 , msg:"Articles not found" }
+    }
     
     return res.status(200).send(articles);
 

--- a/controllers/articles.controller.js
+++ b/controllers/articles.controller.js
@@ -6,10 +6,25 @@ const { fetchArticleById, fetchAllArticles, updateArticleById } = require("../mo
 exports.getAllArticles = async (req, res, next) => {
   try {
 
-    const { sort_by = "created_at", order = "DESC" } = req.query;
+    const { sort_by = "created_at", order = "DESC", topic } = req.query;
 
-    const articles = await fetchAllArticles(sort_by, order)
+    if(topic && typeof topic !== "string") {
+      throw { status: 400 , msg: "Invalid topic"}
+      
+    }
 
+    let articles;
+
+    if(topic) {
+
+     articles = await fetchAllArticles(sort_by, order, topic)
+
+    } else {
+
+      articles = await fetchAllArticles(sort_by, order)
+
+    };
+    
     return res.status(200).send(articles);
 
   } catch (err) {

--- a/endpoints.json
+++ b/endpoints.json
@@ -15,25 +15,51 @@
     }
   },
   "GET /api/articles": {
-    "description": "serves an array of all articles",
-    "queries": [
-      "author",
-      "topic",
-      "sort_by",
-      "order"
-    ],
-    "exampleResponse": {
-      "articles": [
-        {
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "body": "Text from the article..",
-          "created_at": "2018-05-30T15:59:13.341Z",
-          "votes": 0,
-          "comment_count": 6
+    "description": "Retrieves a list of articles. Allows filtering by topic and sorting by different criteria.",
+    "query_parameters": {
+      "sort_by": {
+        "type": "string",
+        "default": "created_at",
+        "description": "The field used to sort the articles. Possible values: 'created_at', 'article_id', 'title', 'votes', 'author', 'comment_count'."
+      },
+      "order": {
+        "type": "string",
+        "default": "DESC",
+        "description": "Sorting order. Possible values: 'ASC' or 'DESC'."
+      },
+      "topic": {
+        "type": "string",
+        "description": "Filters articles by a specific topic."
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "List of articles retrieved successfully.",
+        "example": [
+          {
+            "article_id": 1,
+            "title": "The World of JavaScript",
+            "created_at": "2024-03-10T12:00:00.000Z",
+            "votes": 100,
+            "article_img_url": "https://example.com/image.jpg",
+            "author": "john_doe",
+            "topic": "programming",
+            "comment_count": 5
+          }
+        ]
+      },
+      "400": {
+        "description": "Bad request (invalid parameter).",
+        "example": {
+          "msg": "Invalid sort_by column"
         }
-      ]
+      },
+      "404": {
+        "description": "Topic not found.",
+        "example": {
+          "msg": "Topic not found"
+        }
+      }
     }
   },
   "GET/api/articles/:article_id": {
@@ -62,49 +88,6 @@
         }
       ]
     }
-  },
-  "GET /api/articles?sort_by&order": {
-    "description": "Obtiene una lista de artículos ordenados por un campo especificado, en un orden ascendente o descendente.",
-    "queries": [
-      {
-        "name": "sort_by",
-        "type": "string",
-        "description": "El campo por el que ordenar los artículos.",
-        " default": "created_at",
-        "allowedValues": [
-          "created_at",
-          "article_id",
-          "title",
-          "votes",
-          "article_img_url",
-          "author",
-          "topic",
-          "comment_count"
-        ]
-      },
-      {
-        " name": "order",
-        " type": "string",
-        " description": "El orden en el que se deben ordenar los artículos.",
-        "default": "ASC",
-        " allowedValues": [
-          "ASC",
-          "DESC"
-        ]
-      }
-    ],
-    "exampleResponse": [
-      {
-        " article_id": 1,
-        " title": "Article Title",
-        "created_at": "2021-01-01T00:00:00.000Z",
-        " votes": 100,
-        " article_img_url": "https://example.com/article1.jpg",
-        " author": "john_doe",
-        " topic": "technology",
-        " comment_count": 5
-      }
-    ]
   },
   "GET /api/articles/:article_id/comments": {
     "description": "Fetches a list of comments for a specific article identified by its article ID.",
@@ -274,50 +257,6 @@
         "description": "No users found in the database",
         "body": {
           "msg": "Users not found"
-        }
-      }
-    }
-  },
-  "GET /api/articles?": {
-    "description": "Retrieves a list of articles with optional sorting queries.",
-    "queryParams": [
-      {
-        "name": "sort_by",
-        "type": "string",
-        "description": "Column name to sort the articles by (e.g., 'title', 'votes', 'created_at'). Defaults to 'created_at'."
-      },
-      {
-        "name": "order",
-        "type": "string",
-        "description": "Sorting order: 'asc' for ascending or 'desc' for descending. Defaults to 'desc'."
-      }
-    ],
-    "responses": {
-      "200": {
-        "description": "Returns a list of articles sorted according to the provided parameters.",
-        "content": {
-          "application/json": {
-            "example": [
-              {
-                "article_id": 1,
-                "title": "Interesting Article",
-                "topic": "news",
-                "author": "johndoe",
-                "created_at": "2023-05-15T10:30:00.000Z",
-                "votes": 100,
-                "comment_count": 5
-              },
-              {
-                "article_id": 2,
-                "title": "Another Great Read",
-                "topic": "sports",
-                "author": "janedoe",
-                "created_at": "2023-05-14T08:15:00.000Z",
-                "votes": 75,
-                "comment_count": 2
-              }
-            ]
-          }
         }
       }
     }

--- a/endpoints.json
+++ b/endpoints.json
@@ -90,44 +90,29 @@
     }
   },
   "GET /api/articles/:article_id/comments": {
-    "description": "Fetches a list of comments for a specific article identified by its article ID.",
-    "queries": [
-      {
-        "allowedValues": [
-          "created_at",
-          "article_id",
-          "comment_id",
-          "votes",
-          "body",
-          "author"
+    "description": "Fetches all comments associated with an article by its ID. The comments are ordered by `created_at` in descending order.",
+    "params": {
+      "article_id": {
+        "type": "integer",
+        "description": "The unique identifier for the article.",
+        "required": true
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "Returns the list of comments for the specified article, ordered by `created_at` in descending order.",
+        "body": [
+          {
+            "comment_id": "integer",
+            "body": "string",
+            "votes": "integer",
+            "created_at": "string (ISO 8601 format)",
+            "article_id": "integer",
+            "author": "string"
+          }
         ]
       }
-    ],
-    "params": [
-      {
-        "name": "article_id",
-        "type": "integer",
-        "description": "The ID of the article for which to fetch the comments."
-      }
-    ],
-    "exampleResponse": [
-      {
-        "comment_id": 1,
-        "article_id": 1,
-        "body": "This is a comment on the article.",
-        "votes": 10,
-        "created_at": "2021-01-01T00:00:00.000Z",
-        "author": "john_doe"
-      },
-      {
-        "comment_id": 2,
-        "article_id": 1,
-        "body": "This is another comment.",
-        "votes": 5,
-        "created_at": "2021-01-02T00:00:00.000Z",
-        "author": "jane_doe"
-      }
-    ]
+    }
   },
   "POST /api/articles/:article_id/comments": {
     "description": "Adds a new comment to the specified article.",

--- a/models/articles.model.js
+++ b/models/articles.model.js
@@ -27,7 +27,6 @@ exports.fetchAllArticles = async (sort_by = "created_at", order = "DESC", topic)
 
         const queryParams = []
 
-
         if (topic) {
 
             const topicExist = await db.query(`SELECT* FROM topics WHERE slug = $1;`, [topic]);
@@ -58,11 +57,14 @@ exports.fetchArticleById = async (article_id) => {
     try {
         const articleQuery = `
      SELECT a.article_id, a.title, a.body, a.created_at, a.votes, a.article_img_url,
-       u.username AS author, t.slug AS topic
+       u.username AS author, t.slug AS topic,
+       COUNT(c.comment_id) AS comment_count
 FROM articles a
 LEFT JOIN users u ON a.author = u.username
 LEFT JOIN topics t ON a.topic = t.slug
-WHERE a.article_id = $1; 
+LEFT JOIN comments c ON a.article_id = c.article_id
+WHERE a.article_id = $1
+GROUP BY a.article_id, u.username, t.slug; 
 `;
 
         const queryParams = [article_id];
@@ -72,6 +74,7 @@ WHERE a.article_id = $1;
         if (!articlesResult.rows.length) {
             throw new Error("Article not found");
         }
+
         return articlesResult.rows[0];
 
     } catch (err) { }

--- a/models/comments.model.js
+++ b/models/comments.model.js
@@ -2,9 +2,9 @@ const db = require("../db/connection");
 
 
 exports.fetchArticleCommentsById = async (article_id) => {
-    try {
+  try {
 
-        const commentsQuery = `SELECT c.body, c.comment_id, c.votes, c.created_at,
+    const commentsQuery = `SELECT c.body, c.comment_id, c.votes, c.created_at,
          c.article_id, 
                c.author
 FROM comments c
@@ -12,60 +12,60 @@ WHERE c.article_id = $1
 ORDER BY created_at DESC
 `
 
-        const queryParams = [article_id];
+    const queryParams = [article_id];
 
-        const commentsResult = await db.query(commentsQuery, queryParams);
+    const commentsResult = await db.query(commentsQuery, queryParams);
 
-        if (!commentsResult.rows.length) {
-            return []
-        }
-
-        return commentsResult.rows;
-
-    } catch (err) {
+    if (!commentsResult.rows.length) {
+      return []
     }
+
+    return commentsResult.rows;
+
+  } catch (err) {
+  }
 };
 
 exports.insertComments = async (article_id, body, username) => {
-    try {
-        const insertCommentsQuery = `
+  try {
+    const insertCommentsQuery = `
  INSERT INTO comments 
  (article_id, body, author) 
          VALUES ($1, $2, $3)
          RETURNING comment_id, article_id, body, author, created_at;`
 
-        const commentValues = [article_id, body, username];
+    const commentValues = [article_id, body, username];
 
-        const insertResult = await db.query(insertCommentsQuery, commentValues);
+    const insertResult = await db.query(insertCommentsQuery, commentValues);
 
-        return insertResult.rows[0];
+    return insertResult.rows[0];
 
-    } catch (err) {
-        throw err
-    }
+  } catch (err) {
+    throw err
+  }
 };
 
 exports.eliminateComment = async (comment_id) => {
-    try {
-      const checkQuery = `
+  try {
+    const checkQuery = `
         SELECT * FROM comments WHERE comment_id = $1;
       `;
-      const checkResult = await db.query(checkQuery, [comment_id]);
-  
-      if (checkResult.rows.length === 0) {
-        return []; 
-      }
-  
-      const query = `
+    const checkResult = await db.query(checkQuery, [comment_id]);
+
+    if (checkResult.rows.length === 0) {
+      return [];
+    }
+
+    const query = `
         DELETE FROM comments
         WHERE comment_id = $1
         RETURNING *;
       `;
-      const queryParams = [comment_id];
-      const deleteResult = await db.query(query, queryParams);
-  
-      return deleteResult.rows;
-    } catch (err) {
-      throw err;
-    }
-  };
+    const queryParams = [comment_id];
+    const deleteResult = await db.query(query, queryParams);
+
+    return deleteResult.rows;
+  } catch (err) {
+    throw err;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "husky": "^8.0.2",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
+        "nodemon": "^3.1.9",
         "supertest": "^7.0.0"
       }
     },
@@ -2468,6 +2469,19 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -2680,6 +2694,31 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/ci-info": {
@@ -3568,6 +3607,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -3746,6 +3798,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -3805,6 +3864,19 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -3818,6 +3890,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -3836,6 +3918,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -4918,6 +5013,71 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/nodemon/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nodemon/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -5330,6 +5490,13 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5389,6 +5556,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -5773,6 +5953,32 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6081,6 +6287,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -6150,6 +6366,13 @@
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.20.0",
@@ -8214,6 +8437,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true
+    },
     "body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -8356,6 +8585,22 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      }
     },
     "ci-info": {
       "version": "3.9.0",
@@ -9005,6 +9250,15 @@
         "path-is-absolute": "^1.0.0"
       }
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -9124,6 +9378,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -9166,6 +9426,15 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -9174,6 +9443,12 @@
       "requires": {
         "hasown": "^2.0.2"
       }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -9186,6 +9461,15 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-number": {
       "version": "7.0.0",
@@ -10010,6 +10294,47 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10300,6 +10625,12 @@
         "punycode": "^2.3.1"
       }
     },
+    "pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true
+    },
     "punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10341,6 +10672,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
     },
     "regenerate": {
       "version": "1.4.2",
@@ -10610,6 +10950,23 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+          "dev": true
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -10836,6 +11193,12 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -10886,6 +11249,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
     },
     "undici-types": {
       "version": "6.20.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "husky": "^8.0.2",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
+    "nodemon": "^3.1.9",
     "supertest": "^7.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This Pull Request enhances the GET /api/articles/:article_id endpoint by adding the comment_count field to the response, providing a count of comments for the requested article.

Key Changes:
GET /api/articles/:article_id
Updated fetchArticleById to include comment_count, which represents the number of comments associated with the article.
Modified the SQL query to perform a LEFT JOIN with the comments table and use COUNT(comment_id).
Ensured articles are grouped correctly to avoid duplicate rows.
Updated getArticleById controller to handle the new structure while maintaining existing error handling for invalid or non-existent article_id.
Tests Updated:
Verified that the response includes comment_count.
Ensured the endpoint correctly returns an article with its associated comment count.
Added test cases for articles with and without comments.
Ensured proper handling of invalid (400) and non-existent (404) article_id.